### PR TITLE
Feat/channelization

### DIFF
--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -200,6 +200,9 @@ class ChannelList(Metadatable):
         Args:
             objects(Iterable[chan_type]): A list of objects to add into the ChannelList.
         """
+        # objects may be a generator but we need to iterate over it twice below so
+        # copy it into a tuple just in case.
+        objects = tuple(objects)
         if self._locked:
             raise AttributeError("Cannot extend a locked channel list")
         if not all(isinstance(obj, self._chan_type) for obj in objects):

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -108,10 +108,6 @@ class ChannelList(Metadatable):
             This is used when objects stored inside a channel list are accessible in multiple ways
             and should not be repeated in an instrument snapshot.
 
-    Attributes:
-        parameters (Dict[Parameter]): All the parameters supported by this group of channels.
-
-        functions (Dict[Function]): All the functions supported by this group of channels
     """
 
     def __init__(self, parent, name, chan_type, chan_list=None, snapshotable=True):

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -266,7 +266,7 @@ class ChannelList(Metadatable):
         if name in self._channels[0].parameters:
             # We need to construct a MultiParameter object to get each of the
             # values our of each parameter in our list
-            names = tuple("{}.{}".format(chan.name, name) for chan in self._channels)
+            names = tuple("{}_{}".format(chan.name, name) for chan in self._channels)
             shapes = tuple(() for chan in self._channels) #TODO: Pull shapes intelligently
             labels = tuple(chan.parameters[name].label for chan in self._channels)
             units = tuple(chan.parameters[name].unit for chan in self._channels)
@@ -309,3 +309,12 @@ class MultiChannelInstrumentParameter(MultiParameter):
         Return a tuple containing the data from each of the channels in the list
         """
         return tuple(chan.parameters[self._param_name].get() for chan in self._channels)
+
+    @property
+    def full_names(self):
+        """Overwrite full_names because the instument name is already included in the name.
+           This happens because the instument name is included in the channel name merged into the
+           parameter name above.
+        """
+
+        return self.names

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -110,13 +110,11 @@ class ChannelList(Metadatable):
 
     Attributes:
         parameters (Dict[Parameter]): All the parameters supported by this group of channels.
-            This is implemented as a reference to the parameters in the first channel so if you
-            dynamically modify one or more channels this will not be accurate.
 
         functions (Dict[Function]): All the functions supported by this group of channels
     """
 
-    def __init__(self, parent, name, chan_type: type, chan_list=None, snapshotable=True):
+    def __init__(self, parent, name, chan_type, chan_list=None, snapshotable=True):
         super().__init__()
 
         self._parent = parent
@@ -126,8 +124,6 @@ class ChannelList(Metadatable):
         self._chan_type = chan_type
         self._snapshotable = snapshotable
 
-        self.parameters = {}
-        self.functions = {}
         # If a list of channels is not provided, define a list to store channels.
         # This will eventually become a locked tuple.
         if chan_list is None:
@@ -136,10 +132,10 @@ class ChannelList(Metadatable):
         else:
             self._locked = True
             self._channels = tuple(chan_list)
-            self.parameters = self._channels[0].parameters
-            self.functions = self._channels[0].functions
             if not all(isinstance(chan, chan_type) for chan in self._channels):
                 raise TypeError("All items in this channel list must be of type {}.".format(chan_type.__name__))
+
+
 
     def __getitem__(self, i):
         """
@@ -182,7 +178,7 @@ class ChannelList(Metadatable):
 
         return ChannelList(self._parent, self._name, self._chan_type, self._channels + other._channels)
 
-    def append(self, obj: InstrumentChannel):
+    def append(self, obj):
         """
         When initially constructing the channel list, a new channel to add to the end of the list
 
@@ -195,13 +191,9 @@ class ChannelList(Metadatable):
             raise TypeError("All items in a channel list must be of the same type."
                             " Adding {} to a list of {}.".format(type(obj).__name__,
                                                                  self._chan_type.__name__))
-        if not self.parameters:
-            self.parameters = obj.parameters
-        if not self.functions:
-            self.functions = obj.functions
         return self._channels.append(obj)
 
-    def extend(self, objects: InstrumentChannel):
+    def extend(self, objects):
         """
         Insert an iterable of objects into the list of channels.
 
@@ -215,13 +207,9 @@ class ChannelList(Metadatable):
             raise AttributeError("Cannot extend a locked channel list")
         if not all(isinstance(obj, self._chan_type) for obj in objects):
             raise TypeError("All items in a channel list must be of the same type.")
-        if not self.parameters:
-            self.parameters = objects[0].parameters
-        if not self.functions:
-            self.functions = objects[0].functions
         return self._channels.extend(objects)
 
-    def index(self, obj: InstrumentChannel):
+    def index(self, obj):
         """
         Return the index of the given object
 
@@ -230,7 +218,7 @@ class ChannelList(Metadatable):
         """
         return self._channels.index(obj)
 
-    def insert(self, index, obj: InstrumentChannel):
+    def insert(self, index, obj):
         """
         Insert an object into the channel list at a specific index.
 
@@ -245,10 +233,6 @@ class ChannelList(Metadatable):
             raise TypeError("All items in a channel list must be of the same type."
                             " Adding {} to a list of {}.".format(type(obj).__name__,
                                                                  self._chan_type.__name__))
-        if not self.parameters:
-            self.parameters = obj.parameters
-        if not self.functions:
-            self.functions = obj.functions
         return self._channels.insert(index, obj)
 
     def lock(self):

--- a/qcodes/instrument_drivers/Harvard/Decadac.py
+++ b/qcodes/instrument_drivers/Harvard/Decadac.py
@@ -435,7 +435,7 @@ class Decadac(VisaInstrument, DacReader):
 
     def get_idn(self):
         """
-        Attempt to identify the dac. Since we don't have standard SCPI commands, *IDN will
+        Attempt to identify the dac. Since we don't have standard SCPI commands, ``*IDN`` will
         do nothing on this DAC.
 
         Returns:
@@ -447,7 +447,7 @@ class Decadac(VisaInstrument, DacReader):
 
     def connect_message(self, idn_param='IDN', begin_time=None):
         """
-        Print a connect message, taking into account the lack of a standard *IDN on
+        Print a connect message, taking into account the lack of a standard ``*IDN`` on
         the Harvard DAC
 
         Args:

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -3,7 +3,7 @@ import numpy as np
 from qcodes.instrument.base import Instrument
 from qcodes.utils.validators import Numbers
 from qcodes.instrument.parameter import MultiParameter, ManualParameter
-
+from qcodes.instrument.channel import InstrumentChannel, ChannelList
 
 class MockParabola(Instrument):
     '''
@@ -107,6 +107,38 @@ class DummyInstrument(Instrument):
                                unit="V",
                                vals=Numbers(-800, 400))
 
+class DummyChannel(InstrumentChannel):
+    """
+    A single dummy channel implementation
+    """
+
+    def __init__(self, parent, name, channel):
+        super().__init__(parent, name)
+
+        self._channel = channel
+
+        # Add the various channel parameters
+        self.add_parameter('temperature',
+                           parameter_class=ManualParameter,
+                           initial_value=0,
+                           label="Temperature_{}".format(channel),
+                           unit='K',
+                           vals=Numbers(0, 300))
+
+class DummyChannelInstrument(Instrument):
+    """
+    Dummy instrument with channels
+    """
+
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
+
+        channels = ChannelList(self, "TempSensors", DummyChannel, snapshotable=False)
+        for chan_name in ('A', 'B', 'C', 'D'):
+            channel = DummyChannel(self, 'Chan{}'.format(chan_name), chan_name)
+            channels.append(channel)
+            self.add_submodule(chan_name, channel)
+        self.add_submodule("channels", channels)
 
 class MultiGetter(MultiParameter):
     """

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -134,7 +134,7 @@ class DummyChannelInstrument(Instrument):
         super().__init__(name, **kwargs)
 
         channels = ChannelList(self, "TempSensors", DummyChannel, snapshotable=False)
-        for chan_name in ('A', 'B', 'C', 'D'):
+        for chan_name in ('A', 'B', 'C', 'D', 'E', 'F'):
             channel = DummyChannel(self, 'Chan{}'.format(chan_name), chan_name)
             channels.append(channel)
             self.add_submodule(chan_name, channel)

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import unittest
 
 from qcodes.tests.instrument_mocks import DummyChannelInstrument, DummyChannel
+from qcodes.instrument.channel import ChannelList
 from qcodes.utils.validators import Numbers
 from qcodes.instrument.parameter import ManualParameter
 
@@ -125,8 +126,17 @@ class TestChannels(TestCase):
         self.assertEquals(self.instrument.channels.temperature(), expected)
 
     def test_channel_parameters(self):
-            self.assertTrue('temperature' in self.instrument.channels.parameters)
-            self.assertEqual(len(self.instrument.channels.parameters), 1)
+        self.assertTrue('temperature' in self.instrument.channels.parameters)
+        self.assertEqual(len(self.instrument.channels.parameters), 1)
+
+
+    def test_channel_functions(self):
+        dc = DummyChannel(self.instrument, 'Chan' + 'bar', 'bar')
+        dc.add_function('dummyfunc', call_cmd='foobar')
+        self.assertTrue('dummyfunc' in dc.functions)
+        dcl = ChannelList(self.instrument, 'DummyChannelList', DummyChannel)
+        dcl.append(dc)
+        self.assertTrue('dummyfunc' in dcl.functions)
 
 class TestChannelsLoop(TestCase):
 

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -124,11 +124,9 @@ class TestChannels(TestCase):
         expected = tuple(setpoints[0:2] + [0, 0] + setpoints[2:])
         self.assertEquals(self.instrument.channels.temperature(), expected)
 
-    def test_channel_parameters(self):
-            self.assertTrue('temperature' in self.instrument.channels.parameters)
-            self.assertEqual(len(self.instrument.channels.parameters), 1)
 
 class TestChannelsLoop(TestCase):
+    pass
 
     def setUp(self):
         self.instrument = DummyChannelInstrument(name='testchanneldummy')

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -7,11 +7,11 @@ from qcodes.instrument.parameter import ManualParameter
 
 from hypothesis import given, settings
 import hypothesis.strategies as hst
-from hypothesis.strategies import floats, integers
 from qcodes.loops import Loop
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
+
 
 class TestChannels(TestCase):
 
@@ -31,9 +31,9 @@ class TestChannels(TestCase):
     def test_channels_get(self):
 
         temperatures = self.instrument.channels.temperature.get()
-        self.assertEqual(len(temperatures), 4)
+        self.assertEqual(len(temperatures), 6)
 
-    @given(value=floats(0, 300), channel=integers(0, 3))
+    @given(value=hst.floats(0, 300), channel=hst.integers(0, 3))
     def test_channel_access_is_identical(self, value, channel):
         channel_to_label = {0: 'A', 1: 'B', 2: 'C', 3: "D"}
         label = channel_to_label[channel]
@@ -56,14 +56,13 @@ class TestChannels(TestCase):
         # it's not possible to set via self.instrument.channels.temperature as this is a multi parameter
         # that currently does not support set.
 
-
     def test_add_channel(self):
         name = 'foo'
         channel = DummyChannel(self.instrument, 'Chan'+name, name)
         self.instrument.channels.append(channel)
         self.instrument.add_submodule(name, channel)
 
-        self.assertEqual(len(self.instrument.channels), 5)
+        self.assertEqual(len(self.instrument.channels), 7)
 
         self.instrument.channels.lock()
         # after locking the channels it's not possible to add any more channels
@@ -73,6 +72,23 @@ class TestChannels(TestCase):
             self.instrument.channels.append(channel)
             self.instrument.add_submodule(name, channel)
 
+    @given(setpoints=hst.lists(hst.floats(0, 300), min_size=4, max_size=4))
+    def test_combine_channels(self, setpoints):
+        self.assertEqual(len(self.instrument.channels), 6)
+
+        mychannels = self.instrument.channels[0:2] + self.instrument.channels[4:]
+
+        self.assertEqual(len(mychannels), 4)
+        assert mychannels[0] is self.instrument.A
+        assert mychannels[1] is self.instrument.B
+        assert mychannels[2] is self.instrument.E
+        assert mychannels[3] is self.instrument.F
+
+        for i in range(len(mychannels)):
+            mychannels[i].temperature(setpoints[i])
+
+        expected = tuple(setpoints[0:2] + [0, 0] + setpoints[2:])
+        self.assertEquals(self.instrument.channels.temperature(), expected)
 
 
 class TestChannelsLoop(TestCase):
@@ -86,48 +102,51 @@ class TestChannelsLoop(TestCase):
         del self.instrument
 
     def test_loop_simple(self):
-        loop = Loop(self.instrument.channels[0].temperature.sweep(0,300, 10), 0.001).each(self.instrument.A.temperature)
+        loop = Loop(self.instrument.channels[0].temperature.sweep(0, 300, 10),
+                    0.001).each(self.instrument.A.temperature)
         data = loop.run()
         assert_array_equal(data.testchanneldummy_ChanA_temperature_set.ndarray,
                            data.testchanneldummy_ChanA_temperature.ndarray)
 
     def test_loop_measure_all_channels(self):
         p1 = ManualParameter(name='p1', vals=Numbers(-10, 10))
-        loop = Loop(p1.sweep(-10,10,1), 1e-6).each(self.instrument.channels.temperature)
+        loop = Loop(p1.sweep(-10, 10, 1), 1e-6).each(self.instrument.channels.temperature)
         data = loop.run()
         self.assertEqual(data.p1_set.ndarray.shape, (21, ))
-        for i,chan in enumerate(['A', 'B', 'C', 'D']):
+        self.assertEqual(len(data.arrays), 7)
+        for i, chan in enumerate(['A', 'B', 'C', 'D', 'E', 'F']):
             self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.shape, (21,))
-
 
     def test_loop_measure_channels_individually(self):
         p1 = ManualParameter(name='p1', vals=Numbers(-10, 10))
-        loop = Loop(p1.sweep(-10,10,1), 1e-6).each(self.instrument.channels[0].temperature,
-                                                   self.instrument.channels[1].temperature,
-                                                   self.instrument.channels[2].temperature,
-                                                   self.instrument.channels[3].temperature)
+        loop = Loop(p1.sweep(-10, 10, 1), 1e-6).each(self.instrument.channels[0].temperature,
+                                                     self.instrument.channels[1].temperature,
+                                                     self.instrument.channels[2].temperature,
+                                                     self.instrument.channels[3].temperature)
         data = loop.run()
         self.assertEqual(data.p1_set.ndarray.shape, (21, ))
-        for i,chan in enumerate(['A', 'B', 'C', 'D']):
+        for i, chan in enumerate(['A', 'B', 'C', 'D']):
             self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.shape, (21,))
 
-    @given(values=hst.tuples(floats(0, 300), floats(0, 300), floats(0, 300), floats(0, 300)))
+    @given(values=hst.lists(hst.floats(0, 300), min_size=4, max_size=4))
     @settings(max_examples=10)
     def test_loop_measure_channels_by_name(self, values):
         p1 = ManualParameter(name='p1', vals=Numbers(-10, 10))
         for i in range(4):
             self.instrument.channels[i].temperature(values[i])
-        loop = Loop(p1.sweep(-10,10,1), 1e-6).each(self.instrument.A.temperature,
-                                                      self.instrument.B.temperature,
-                                                      self.instrument.C.temperature,
-                                                      self.instrument.D.temperature)
+        loop = Loop(p1.sweep(-10, 10, 1), 1e-6).each(self.instrument.A.temperature,
+                                                     self.instrument.B.temperature,
+                                                     self.instrument.C.temperature,
+                                                     self.instrument.D.temperature)
         data = loop.run()
         self.assertEqual(data.p1_set.ndarray.shape, (21, ))
-        for i,chan in enumerate(['A', 'B', 'C', 'D']):
+        for i, chan in enumerate(['A', 'B', 'C', 'D']):
             self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.shape, (21,))
             self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.max(), values[i])
+            self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.min(), values[i])
 
-    @given(loop_channels=hst.lists(integers(0, 3), min_size=2, max_size=2, unique=True), measure_channel=integers(0, 3))
+    @given(loop_channels=hst.lists(hst.integers(0, 3), min_size=2, max_size=2, unique=True),
+           measure_channel=hst.integers(0, 3))
     @settings(max_examples=10)
     def test_nested_loop_over_channels(self, loop_channels, measure_channel):
         channel_to_label = {0: 'A', 1: 'B', 2: 'C', 3: "D"}
@@ -139,16 +158,17 @@ class TestChannelsLoop(TestCase):
         self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature_set'.format(
             channel_to_label[loop_channels[0]])).ndarray.shape, (21,))
         self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature_set'.format(
-            channel_to_label[loop_channels[1]])).ndarray.shape, (21,11,))
+            channel_to_label[loop_channels[1]])).ndarray.shape, (21, 11,))
         self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(
-            channel_to_label[measure_channel])).ndarray.shape, (21,11))
+            channel_to_label[measure_channel])).ndarray.shape, (21, 11))
 
         assert_array_equal(getattr(data, 'testchanneldummy_Chan{}_temperature_set'.format(
             channel_to_label[loop_channels[0]])).ndarray,
-                           np.arange(0,10.1,0.5))
+                           np.arange(0, 10.1, 0.5))
 
         expected_array = np.repeat(np.arange(50, 51.01, 0.1).reshape(1, 11), 21, axis=0)
-        array = getattr(data, 'testchanneldummy_Chan{}_temperature_set'.format(channel_to_label[loop_channels[1]])).ndarray
+        array = getattr(data, 'testchanneldummy_Chan'
+                              '{}_temperature_set'.format(channel_to_label[loop_channels[1]])).ndarray
         assert_allclose(array, expected_array)
 
 if __name__ == '__main__':

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 import unittest
 
 from qcodes.tests.instrument_mocks import DummyChannelInstrument, DummyChannel
-from qcodes.instrument.channel import ChannelList
 from qcodes.utils.validators import Numbers
 from qcodes.instrument.parameter import ManualParameter
 
@@ -126,17 +125,8 @@ class TestChannels(TestCase):
         self.assertEquals(self.instrument.channels.temperature(), expected)
 
     def test_channel_parameters(self):
-        self.assertTrue('temperature' in self.instrument.channels.parameters)
-        self.assertEqual(len(self.instrument.channels.parameters), 1)
-
-
-    def test_channel_functions(self):
-        dc = DummyChannel(self.instrument, 'Chan' + 'bar', 'bar')
-        dc.add_function('dummyfunc', call_cmd='foobar')
-        self.assertTrue('dummyfunc' in dc.functions)
-        dcl = ChannelList(self.instrument, 'DummyChannelList', DummyChannel)
-        dcl.append(dc)
-        self.assertTrue('dummyfunc' in dcl.functions)
+            self.assertTrue('temperature' in self.instrument.channels.parameters)
+            self.assertEqual(len(self.instrument.channels.parameters), 1)
 
 class TestChannelsLoop(TestCase):
 

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -1,21 +1,32 @@
 from unittest import TestCase
-import gc
+import unittest
 
-from .instrument_mocks import DummyChannelInstrument, DummyChannel
+from qcodes.tests.instrument_mocks import DummyChannelInstrument, DummyChannel
+from qcodes.utils.validators import Numbers
+from qcodes.instrument.parameter import ManualParameter
 
-from hypothesis import given
+from hypothesis import given, settings
+import hypothesis.strategies as hst
 from hypothesis.strategies import floats, integers
+from qcodes.loops import Loop
 
+
+from numpy.testing import assert_array_equal
 
 class TestChannels(TestCase):
 
     def setUp(self):
+        # print("setup")
         self.instrument = DummyChannelInstrument(name='testchanneldummy')
 
     def tearDown(self):
-        # force gc run
+
+        self.instrument.close()
         del self.instrument
-        gc.collect()
+        # del self.instrument is not sufficient in general because the __del__ method is
+        # first invoked when there are 0 (non weak) references to the instrument. If a test
+        # fails the unittest framework will keep a reference to the instrument is removed from
+        # the testcase and __del__ is not invoked until all the tests have run.
 
     def test_channels_get(self):
 
@@ -54,3 +65,81 @@ class TestChannels(TestCase):
 
         self.assertEqual(len(self.instrument.channels), 5)
 
+        self.instrument.channels.lock()
+        # after locking the channels it's not possible to add any more channels
+        with self.assertRaises(AttributeError):
+            name = 'bar'
+            channel = DummyChannel(self.instrument, 'Chan' + name, name)
+            self.instrument.channels.append(channel)
+            self.instrument.add_submodule(name, channel)
+
+
+
+class TestChannelsLoop(TestCase):
+    pass
+
+    def setUp(self):
+        self.instrument = DummyChannelInstrument(name='testchanneldummy')
+
+    def tearDown(self):
+        self.instrument.close()
+        del self.instrument
+
+    def test_loop_simple(self):
+        loop = Loop(self.instrument.channels[0].temperature.sweep(0,300, 10), 0.001).each(self.instrument.A.temperature)
+        data = loop.run()
+        assert_array_equal(data.testchanneldummy_ChanA_temperature_set.ndarray,
+                           data.testchanneldummy_ChanA_temperature.ndarray)
+
+    def test_loop_measure_all_channels(self):
+        p1 = ManualParameter(name='p1', vals=Numbers(-10, 10))
+        loop = Loop(p1.sweep(-10,10,1), 1e-6).each(self.instrument.channels.temperature)
+        data = loop.run()
+        self.assertEqual(data.p1_set.ndarray.shape, (21, ))
+        for i,chan in enumerate(['A', 'B', 'C', 'D']):
+            self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.shape, (21,))
+
+
+    def test_loop_measure_channels_individually(self):
+        p1 = ManualParameter(name='p1', vals=Numbers(-10, 10))
+        loop = Loop(p1.sweep(-10,10,1), 1e-6).each(self.instrument.channels[0].temperature,
+                                                   self.instrument.channels[1].temperature,
+                                                   self.instrument.channels[2].temperature,
+                                                   self.instrument.channels[3].temperature)
+        data = loop.run()
+        self.assertEqual(data.p1_set.ndarray.shape, (21, ))
+        for i,chan in enumerate(['A', 'B', 'C', 'D']):
+            self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.shape, (21,))
+
+    @given(values=hst.tuples(floats(0, 300), floats(0, 300), floats(0, 300), floats(0, 300)))
+    @settings(max_examples=10)
+    def test_loop_measure_channels_by_name(self, values):
+        p1 = ManualParameter(name='p1', vals=Numbers(-10, 10))
+        for i in range(4):
+            self.instrument.channels[i].temperature(values[i])
+        loop = Loop(p1.sweep(-10,10,1), 1e-6).each(self.instrument.A.temperature,
+                                                      self.instrument.B.temperature,
+                                                      self.instrument.C.temperature,
+                                                      self.instrument.D.temperature)
+        data = loop.run()
+        self.assertEqual(data.p1_set.ndarray.shape, (21, ))
+        for i,chan in enumerate(['A', 'B', 'C', 'D']):
+            self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.shape, (21,))
+            self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.max(), values[i])
+    #
+    # @given(loop_channel=hst.lists(integers(0, 3), measure_channel=integers(0, 3))
+    # @settings(max_examples=10)
+    def test_nested_loop_over_channels(self, loop_channels=(0,1), measure_channel=2):
+        channel_to_label = {0: 'A', 1: 'B', 2: 'C', 3: "D"}
+        loop = Loop(self.instrument.channels[loop_channels[0]].temperature.sweep(0,10,1))
+        loop = loop.loop(self.instrument.channels[loop_channels[1]].temperature.sweep(50,51,0.1))
+        loop = loop.each(self.instrument.channels[measure_channel].temperature)
+        data = loop.run()
+        # for i,chan in enumerate(['A', 'B', 'C', 'D']):
+        #     self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.shape, (21,))
+        #     self.assertEqual(getattr(data, 'testchanneldummy_Chan{}_temperature'.format(chan)).ndarray.max(), values[i])
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -27,10 +27,24 @@ class TestChannels(TestCase):
         channel_to_label = {0: 'A', 1: 'B', 2: 'C', 3: "D"}
         label = channel_to_label[channel]
         channel_via_label = getattr(self.instrument, label)
+        # set via labeled channel
         channel_via_label.temperature(value)
         self.assertEqual(channel_via_label.temperature(), value)
         self.assertEqual(self.instrument.channels[channel].temperature(), value)
         self.assertEqual(self.instrument.channels.temperature()[channel], value)
+        # reset
+        channel_via_label.temperature(0)
+        self.assertEqual(channel_via_label.temperature(), 0)
+        self.assertEqual(self.instrument.channels[channel].temperature(), 0)
+        self.assertEqual(self.instrument.channels.temperature()[channel], 0)
+        # set via index into list
+        self.instrument.channels[channel].temperature(value)
+        self.assertEqual(channel_via_label.temperature(), value)
+        self.assertEqual(self.instrument.channels[channel].temperature(), value)
+        self.assertEqual(self.instrument.channels.temperature()[channel], value)
+        # it's not possible to set via self.instrument.channels.temperature as this is a multi parameter
+        # that currently does not support set.
+
 
     def test_add_channel(self):
         name = 'foo'
@@ -39,4 +53,4 @@ class TestChannels(TestCase):
         self.instrument.add_submodule(name, channel)
 
         self.assertEqual(len(self.instrument.channels), 5)
-        
+

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -124,9 +124,11 @@ class TestChannels(TestCase):
         expected = tuple(setpoints[0:2] + [0, 0] + setpoints[2:])
         self.assertEquals(self.instrument.channels.temperature(), expected)
 
+    def test_channel_parameters(self):
+            self.assertTrue('temperature' in self.instrument.channels.parameters)
+            self.assertEqual(len(self.instrument.channels.parameters), 1)
 
 class TestChannelsLoop(TestCase):
-    pass
 
     def setUp(self):
         self.instrument = DummyChannelInstrument(name='testchanneldummy')

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -114,10 +114,10 @@ class TestChannels(TestCase):
         mychannels = self.instrument.channels[0:2] + self.instrument.channels[4:]
 
         self.assertEqual(len(mychannels), 4)
-        assert mychannels[0] is self.instrument.A
-        assert mychannels[1] is self.instrument.B
-        assert mychannels[2] is self.instrument.E
-        assert mychannels[3] is self.instrument.F
+        self.assertIs(mychannels[0], self.instrument.A)
+        self.assertIs(mychannels[1], self.instrument.B)
+        self.assertIs(mychannels[2], self.instrument.E)
+        self.assertIs(mychannels[3], self.instrument.F)
 
         for i in range(len(mychannels)):
             mychannels[i].temperature(setpoints[i])

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+import gc
+
+from .instrument_mocks import DummyChannelInstrument, DummyChannel
+
+from hypothesis import given
+from hypothesis.strategies import floats, integers
+
+
+class TestChannels(TestCase):
+
+    def setUp(self):
+        self.instrument = DummyChannelInstrument(name='testchanneldummy')
+
+    def tearDown(self):
+        # force gc run
+        del self.instrument
+        gc.collect()
+
+    def test_channels_get(self):
+
+        temperatures = self.instrument.channels.temperature.get()
+        self.assertEqual(len(temperatures), 4)
+
+    @given(value=floats(0, 300), channel=integers(0, 3))
+    def test_channel_access_is_identical(self, value, channel):
+        channel_to_label = {0: 'A', 1: 'B', 2: 'C', 3: "D"}
+        label = channel_to_label[channel]
+        channel_via_label = getattr(self.instrument, label)
+        channel_via_label.temperature(value)
+        self.assertEqual(channel_via_label.temperature(), value)
+        self.assertEqual(self.instrument.channels[channel].temperature(), value)
+        self.assertEqual(self.instrument.channels.temperature()[channel], value)
+
+    def test_add_channel(self):
+        name = 'foo'
+        channel = DummyChannel(self.instrument, 'Chan'+name, name)
+        self.instrument.channels.append(channel)
+        self.instrument.add_submodule(name, channel)
+
+        self.assertEqual(len(self.instrument.channels), 5)
+        

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -72,6 +72,15 @@ class TestChannels(TestCase):
             self.instrument.channels.append(channel)
             self.instrument.add_submodule(name, channel)
 
+    def test_add_channels_from_generator(self):
+        n_channels = len(self.instrument.channels)
+        names = ('foo', 'bar', 'foobar')
+        channels = (DummyChannel(self.instrument, 'Chan'+name, name) for name in names)
+        self.instrument.channels.extend(channels)
+
+        self.assertEqual(len(self.instrument.channels), n_channels + len(names))
+
+
     @given(setpoints=hst.lists(hst.floats(0, 300), min_size=4, max_size=4))
     def test_combine_channels(self, setpoints):
         self.assertEqual(len(self.instrument.channels), 6)

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -17,6 +17,8 @@ class TestInstrument(TestCase):
 
     def tearDown(self):
         # force gc run
+        self.instrument.close()
+        self.instrument2.close()
         del self.instrument
         del self.instrument2
         gc.collect()
@@ -36,6 +38,7 @@ class TestInstrument(TestCase):
         self.assertEqual(Instrument.instances(), [])
         self.assertEqual(DummyInstrument.instances(), [self.instrument])
         self.assertEqual(self.instrument.instances(), [self.instrument])
+
 
     def test_attr_access(self):
         instrument = self.instrument

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ coverage
 pytest-cov
 pytest
 codacy-coverage
+hypothesis


### PR DESCRIPTION
@spauka I have made some changes in my own branch https://github.com/jenshnielsen/qcodes/tree/feat/channelization and I will open a pr against your branch for you to review but in brief I have done the following

* Added some tests for the channels as well as usage within Loops
* Replace a `.` with a `_` in the names generated in line 269. Otherwise datasets cannon be retrieved as member attributes on the returned data from a loop but has to be found via arrays
* overwrite full_name of the MultiParameter, otherwise names have the base instrument applied twice as in `myinstrument_myinstrument_chanA_temperature`
* Add parameters and functions to ChannelList, this was documented but not implemented. I could also be convinced to go the other way and delete this. 

